### PR TITLE
Add a delayed version for JPEG loading

### DIFF
--- a/include/hpdf.h
+++ b/include/hpdf.h
@@ -790,6 +790,10 @@ HPDF_LoadJpegImageFromFile (HPDF_Doc      pdf,
                             const char    *filename);
 
 HPDF_EXPORT(HPDF_Image)
+HPDF_LoadJpegImageFromFile2 (HPDF_Doc      pdf,
+                            const char    *filename);
+
+HPDF_EXPORT(HPDF_Image)
 HPDF_LoadJpegImageFromMem   (HPDF_Doc      pdf,
                       const HPDF_BYTE     *buffer,
                             HPDF_UINT      size);

--- a/include/hpdf_image.h
+++ b/include/hpdf_image.h
@@ -48,7 +48,8 @@ HPDF_Image_LoadPngImage  (HPDF_MMgr        mmgr,
 HPDF_Image
 HPDF_Image_LoadJpegImage  (HPDF_MMgr        mmgr,
                            HPDF_Stream      jpeg_data,
-                           HPDF_Xref        xref);
+                           HPDF_Xref        xref,
+                           HPDF_BOOL        delayed_loading);
 
 HPDF_Image
 HPDF_Image_LoadJpegImageFromMem  (HPDF_MMgr        mmgr,

--- a/src/hpdf_doc.c
+++ b/src/hpdf_doc.c
@@ -1738,6 +1738,36 @@ HPDF_LoadJpegImageFromFile  (HPDF_Doc     pdf,
     HPDF_Stream imagedata;
     HPDF_Image image;
 
+    HPDF_PTRACE ((" HPDF_LoadJpegImageFromFile2\n"));
+
+    if (!HPDF_HasDoc (pdf))
+        return NULL;
+
+    /* create file stream */
+    imagedata = HPDF_FileReader_New (pdf->mmgr, filename);
+
+    if (HPDF_Stream_Validate (imagedata))
+        image = HPDF_Image_LoadJpegImage (pdf->mmgr, imagedata, pdf->xref, HPDF_FALSE);
+    else
+        image = NULL;
+
+    /* destroy file stream */
+    HPDF_Stream_Free (imagedata);
+
+    if (!image)
+        HPDF_CheckError (&pdf->error);
+
+    return image;
+}
+
+HPDF_EXPORT(HPDF_Image)
+HPDF_LoadJpegImageFromFile2  (HPDF_Doc     pdf,
+                             const char  *filename)
+{
+    HPDF_Stream imagedata;
+    HPDF_Image image;
+    HPDF_String fname;
+
     HPDF_PTRACE ((" HPDF_LoadJpegImageFromFile\n"));
 
     if (!HPDF_HasDoc (pdf))
@@ -1747,15 +1777,33 @@ HPDF_LoadJpegImageFromFile  (HPDF_Doc     pdf,
     imagedata = HPDF_FileReader_New (pdf->mmgr, filename);
 
     if (HPDF_Stream_Validate (imagedata))
-        image = HPDF_Image_LoadJpegImage (pdf->mmgr, imagedata, pdf->xref);
+        image = HPDF_Image_LoadJpegImage (pdf->mmgr, imagedata, pdf->xref, HPDF_TRUE);
     else
         image = NULL;
 
     /* destroy file stream */
     HPDF_Stream_Free (imagedata);
 
-    if (!image)
+    if (!image) {
         HPDF_CheckError (&pdf->error);
+        return NULL;
+    }
+
+    /* Add filename to image dictionary as a hidden entry.
+     * it is used when the image data is needed.
+     */
+    fname = HPDF_String_New (pdf->mmgr, filename, NULL);
+    if (!fname) {
+        HPDF_CheckError (&pdf->error);
+        return NULL;
+    }
+
+    fname->header.obj_id |= HPDF_OTYPE_HIDDEN;
+
+    if ((HPDF_Dict_Add (image, "_FILE_NAME", fname)) != HPDF_OK) {
+        HPDF_CheckError (&pdf->error);
+        return NULL;
+    }
 
     return image;
 }


### PR DESCRIPTION
Haru already exposes a `HPDF_LoadPngImageFromFile2` that delays the in-memory loading of the PNG file to writing time. This commits adds a similar `HPDF_LoadJpegImageFromFile2` that delays loading of JPEG files to writing time as well.