### PR TITLE
Remove method to set user password

### DIFF
--- a/include/hpdf.h
+++ b/include/hpdf.h
@@ -931,10 +931,6 @@ HPDF_SetPassword  (HPDF_Doc      pdf,
                    const char   *owner_passwd,
                    const char   *user_passwd);
 
-HPDF_EXPORT(HPDF_STATUS)
-HPDF_SetUserPassword  (HPDF_Doc          pdf,
-					   const char  *user_passwd);
-
 
 HPDF_EXPORT(HPDF_STATUS)
 HPDF_SetPermission  (HPDF_Doc    pdf,

--- a/include/hpdf_encryptdict.h
+++ b/include/hpdf_encryptdict.h
@@ -47,10 +47,6 @@ HPDF_EncryptDict_SetPassword  (HPDF_EncryptDict  dict,
                                const char   *owner_passwd,
                                const char   *user_passwd);
 
-HPDF_STATUS
-HPDF_EncryptDict_SetUserPassword  (HPDF_EncryptDict  dict,
-                               const char   *user_passwd);
-
 
 HPDF_BOOL
 HPDF_EncryptDict_Validate  (HPDF_EncryptDict  dict);

--- a/src/hpdf_doc.c
+++ b/src/hpdf_doc.c
@@ -469,28 +469,6 @@ HPDF_SetPassword  (HPDF_Doc          pdf,
     return HPDF_Doc_SetEncryptOn (pdf);
 }
 
-HPDF_EXPORT(HPDF_STATUS)
-HPDF_SetUserPassword  (HPDF_Doc          pdf,
-                   const char  *user_passwd)
-{
-    HPDF_PTRACE ((" HPDF_SetUserPassword\n"));
-
-    if (!HPDF_HasDoc (pdf))
-        return HPDF_DOC_INVALID_OBJECT;
-
-    if (!pdf->encrypt_dict) {
-        pdf->encrypt_dict = HPDF_EncryptDict_New (pdf->mmgr, pdf->xref);
-
-        if (!pdf->encrypt_dict)
-            return HPDF_CheckError (&pdf->error);
-    }
-
-    if (HPDF_EncryptDict_SetUserPassword (pdf->encrypt_dict, user_passwd) != HPDF_OK)
-        return HPDF_CheckError (&pdf->error);
-
-    return HPDF_Doc_SetEncryptOn (pdf);
-}
-
 
 HPDF_EXPORT(HPDF_STATUS)
 HPDF_SetPermission  (HPDF_Doc    pdf,

--- a/src/hpdf_encryptdict.c
+++ b/src/hpdf_encryptdict.c
@@ -204,20 +204,6 @@ HPDF_EncryptDict_SetPassword  (HPDF_EncryptDict  dict,
     return HPDF_OK;
 }
 
-HPDF_STATUS
-HPDF_EncryptDict_SetUserPassword  (HPDF_EncryptDict  dict,
-                               const char   *user_passwd)
-{
-    HPDF_Encrypt attr = (HPDF_Encrypt)dict->attr;
-
-    HPDF_PTRACE((" HPDF_EncryptDict_SetUserPassword\n"));
-
-    HPDF_PadOrTrancatePasswd (user_passwd, attr->owner_passwd);
-    HPDF_PadOrTrancatePasswd (user_passwd, attr->user_passwd);
-
-    return HPDF_OK;
-}
-
 
 HPDF_BOOL
 HPDF_EncryptDict_Validate  (HPDF_EncryptDict  dict)


### PR DESCRIPTION
It's no longer useful now that the `setPassword` method allows the same user and owner password (cf https://github.com/libharu/libharu/pull/346).